### PR TITLE
Update hero background imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-<base href="https://64ggvhgowmikm.ok.kimi.link">
+<base href="./">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TravelProSchool - Онлайн-школа турагентов</title>
@@ -52,10 +52,10 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background-image: url('./resources/hero-bg.jpg');
+            background-image: url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1920&q=80');
             background-size: cover;
             background-position: center;
-            opacity: 0.3;
+            opacity: 0.45;
             z-index: 1;
         }
         

--- a/index.html
+++ b/index.html
@@ -48,14 +48,13 @@
         .hero-bg::before {
             content: '';
             position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-image: url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1920&q=80');
+            inset: 0;
+            background-image: linear-gradient(120deg, rgba(38, 70, 83, 0.55) 0%, rgba(38, 70, 83, 0.15) 55%, rgba(244, 162, 97, 0.25) 100%),
+                url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1920&q=80');
             background-size: cover;
             background-position: center;
-            opacity: 0.45;
+            background-repeat: no-repeat;
+            opacity: 0.35;
             z-index: 1;
         }
         

--- a/main.js
+++ b/main.js
@@ -1,0 +1,145 @@
+"use strict";
+
+document.addEventListener("DOMContentLoaded", () => {
+    const fadeElements = document.querySelectorAll(".fade-in");
+    if (fadeElements.length) {
+        const observer = new IntersectionObserver(
+            entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add("visible");
+                        observer.unobserve(entry.target);
+                    }
+                });
+            },
+            { threshold: 0.2 }
+        );
+
+        fadeElements.forEach(element => observer.observe(element));
+    }
+
+    const mobileMenuBtn = document.getElementById("mobile-menu-btn");
+    const mobileMenu = document.getElementById("mobile-menu");
+
+    if (mobileMenuBtn && mobileMenu) {
+        const toggleMenu = () => mobileMenu.classList.toggle("hidden");
+        mobileMenuBtn.addEventListener("click", toggleMenu);
+
+        mobileMenu.querySelectorAll("a").forEach(link => {
+            link.addEventListener("click", () => {
+                if (!mobileMenu.classList.contains("hidden")) {
+                    mobileMenu.classList.add("hidden");
+                }
+            });
+        });
+    }
+
+    const courseSelect = document.getElementById("course-select");
+    const certificationCheckbox = document.getElementById("certification");
+    const jobPlacementCheckbox = document.getElementById("job-placement");
+    const totalPriceEl = document.getElementById("total-price");
+    const discountEl = document.getElementById("discount");
+    const formatButtons = document.querySelectorAll(".format-btn");
+
+    const coursePrices = {
+        basic: 49900,
+        luxury: 89900,
+        corporate: 129900,
+        combo: 199900,
+    };
+
+    const formatMultipliers = {
+        online: 1,
+        mentorship: 1.25,
+    };
+
+    const optionPrices = {
+        certification: 15000,
+        jobPlacement: 25000,
+    };
+
+    let selectedFormat = "online";
+
+    const setActiveFormat = (target) => {
+        formatButtons.forEach((button) => {
+            button.classList.remove("bg-primary", "text-white", "border-transparent", "shadow-lg");
+            button.classList.add("border-gray-300", "text-dark");
+        });
+
+        target.classList.remove("border-gray-300", "text-dark");
+        target.classList.add("bg-primary", "text-white", "border-transparent", "shadow-lg");
+        selectedFormat = target.dataset.format || "online";
+    };
+
+    const formatPrice = (value) => `${value.toLocaleString("ru-RU")} ₽`;
+
+    const calculatePrice = () => {
+        const courseKey = courseSelect?.value;
+        const basePrice = courseKey && coursePrices[courseKey] ? coursePrices[courseKey] : 0;
+        const multiplier = formatMultipliers[selectedFormat] || 1;
+
+        let optionsTotal = 0;
+        if (certificationCheckbox?.checked) {
+            optionsTotal += optionPrices.certification;
+        }
+        if (jobPlacementCheckbox?.checked) {
+            optionsTotal += optionPrices.jobPlacement;
+        }
+
+        const subtotal = Math.round(basePrice * multiplier + optionsTotal);
+
+        let discount = 0;
+        if (courseKey === "combo" && subtotal >= 199900) {
+            discount = 20000;
+        } else if (certificationCheckbox?.checked && jobPlacementCheckbox?.checked) {
+            discount = 5000;
+        }
+
+        const total = Math.max(0, subtotal - discount);
+
+        if (totalPriceEl) {
+            totalPriceEl.textContent = formatPrice(total);
+        }
+        if (discountEl) {
+            discountEl.textContent = formatPrice(discount);
+        }
+    };
+
+    if (formatButtons.length) {
+        const defaultButton = Array.from(formatButtons).find(button => button.dataset.format === selectedFormat);
+        if (defaultButton) {
+            setActiveFormat(defaultButton);
+        }
+
+        formatButtons.forEach((button) => {
+            button.addEventListener("click", () => {
+                setActiveFormat(button);
+                calculatePrice();
+            });
+        });
+    }
+
+    [courseSelect, certificationCheckbox, jobPlacementCheckbox].forEach((element) => {
+        element?.addEventListener("change", calculatePrice);
+    });
+
+    calculatePrice();
+
+    if (window.Splide) {
+        const slider = new window.Splide("#testimonials-slider", {
+            type: "loop",
+            perPage: 2,
+            gap: "2rem",
+            autoplay: true,
+            interval: 6000,
+            pauseOnHover: true,
+            breakpoints: {
+                1024: {
+                    perPage: 1,
+                },
+            },
+        });
+
+        slider.mount();
+    }
+});


### PR DESCRIPTION
## Summary
- add a client-side script to reveal fade-in sections when they enter the viewport
- enable the tuition calculator, mobile menu toggle, and Splide testimonials carousel on the homepage
- refresh the hero background with high-resolution travel photography for a stronger first impression

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc2c888c08832c87d3191ffe627138