### PR TITLE
Add Next.js redesign and link from classic homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,16 +148,27 @@
                     <a href="contact.html" class="text-dark hover:text-primary transition-colors">Контакты</a>
                 </div>
                 
-                <button class="btn-primary text-white px-6 py-2 rounded-lg font-medium">
-                    Войти
-                </button>
+                <div class="hidden md:flex items-center space-x-3">
+                    <a href="new-design" class="btn-primary text-white px-6 py-2 rounded-lg font-medium inline-flex items-center justify-center shadow-sm">
+                        Перейти на новый дизайн
+                    </a>
+                    <button class="btn-primary text-white px-6 py-2 rounded-lg font-medium">
+                        Войти
+                    </button>
+                </div>
                 
                 <!-- Mobile menu button -->
-                <button class="md:hidden p-2" id="mobile-menu-btn">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                    </svg>
-                </button>
+                <div class="md:hidden flex items-center space-x-2">
+                    <a href="new-design" class="btn-primary text-white px-4 py-2 rounded-lg font-medium inline-flex items-center justify-center shadow-sm text-sm">
+                        Новый дизайн
+                    </a>
+                    <button class="btn-primary text-white px-4 py-2 rounded-lg font-medium text-sm">Войти</button>
+                    <button class="md:hidden p-2" id="mobile-menu-btn">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
             </div>
             
             <!-- Mobile menu -->

--- a/new-design/.eslintrc.json
+++ b/new-design/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/new-design/.gitignore
+++ b/new-design/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+/.next
+/out
+.next
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/new-design/README.md
+++ b/new-design/README.md
@@ -1,0 +1,20 @@
+# TravelProSchool — новый дизайн
+
+Современная версия сайта TravelProSchool на Next.js 14 с компонентами shadcn/ui.
+
+## Запуск проекта
+
+```bash
+cd new-design
+npm install
+npm run dev
+```
+
+Приложение поднимется на `http://localhost:3000`.
+
+## Скрипты
+
+- `npm run dev` — запуск режима разработки.
+- `npm run build` — production-сборка.
+- `npm run start` — запуск production-сборки.
+- `npm run lint` — проверка кода линтером.

--- a/new-design/app/globals.css
+++ b/new-design/app/globals.css
@@ -1,0 +1,57 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 207 49% 36%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 28 87% 67%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 12 77% 55%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 72.2% 50.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 215 20.2% 65.1%;
+  --radius: 0.8rem;
+}
+
+* {
+  @apply border-border;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+  font-feature-settings: "ss01" on, "ss03" on;
+}
+
+.gradient-text {
+  background: linear-gradient(135deg, #F4A261 0%, #E76F51 45%, #F4D35E 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.section-subtitle {
+  @apply text-muted-foreground text-base sm:text-lg max-w-2xl mx-auto;
+}
+
+.shadow-soft {
+  box-shadow: 0 30px 60px -15px rgba(45, 90, 135, 0.25);
+}
+
+@layer utilities {
+  .bg-grid {
+    background-image: linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+}

--- a/new-design/app/layout.tsx
+++ b/new-design/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { Plus_Jakarta_Sans } from "next/font/google";
+import "./globals.css";
+
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin", "cyrillic"],
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  title: "TravelProSchool — Современная платформа обучения турагентов",
+  description:
+    "Обновленная платформа TravelProSchool с интерактивными форматами обучения, экспертной поддержкой и инструментами для карьерного роста в туризме.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ru" suppressHydrationWarning>
+      <body className={jakarta.className}>{children}</body>
+    </html>
+  );
+}

--- a/new-design/app/page.tsx
+++ b/new-design/app/page.tsx
@@ -1,0 +1,326 @@
+import Image from "next/image";
+import { ArrowRight, Compass, LineChart, Map, Users } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
+
+const mentors = [
+  {
+    name: "Анна Громова",
+    role: "Эксперт по премиальным маршрутам",
+    image:
+      "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=256&q=80",
+  },
+  {
+    name: "Михаил Дроздов",
+    role: "Руководитель агентства TravelPro",
+    image:
+      "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=256&q=80",
+  },
+  {
+    name: "Екатерина Лазутина",
+    role: "Специалист по бизнес-туризму",
+    image:
+      "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=256&q=80",
+  },
+];
+
+const achievements = [
+  { value: "8 500+", label: "выпускников по всему миру" },
+  { value: "120", label: "практических кейсов и сценариев" },
+  { value: "45%", label: "средний рост дохода выпускников" },
+];
+
+const modules = [
+  {
+    title: "Стратегия и аналитика",
+    description:
+      "Изучайте современные тренды туризма, анализируйте спрос и формируйте сильные продуктовые линейки.",
+    icon: LineChart,
+  },
+  {
+    title: "Создание маршрутов",
+    description:
+      "Конструируйте путешествия под любой запрос: от семейных до корпоративных с опорой на реальный опыт.",
+    icon: Map,
+  },
+  {
+    title: "Коммуникации с клиентами",
+    description:
+      "Освойте сервисный стандарт TravelPro, научитесь выстраивать долгосрочные отношения и удерживать клиентов.",
+    icon: Users,
+  },
+];
+
+const testimonials = [
+  {
+    name: "Наталья Сафонова",
+    role: "Основатель агентства NataTravel",
+    message:
+      "После курса мы расширили линейку авторских туров и увеличили оборот в 1.8 раза. Особенно помогли практикумы с наставниками.",
+    image:
+      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=160&q=80",
+  },
+  {
+    name: "Игорь Левицкий",
+    role: "Корпоративный менеджер по туризму",
+    message:
+      "Интерактивные симуляторы переговоров с клиентами — это must-have. Теперь команда закрывает заявки быстрее и увереннее.",
+    image:
+      "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=160&q=80",
+  },
+];
+
+export default function Home() {
+  return (
+    <main className="relative">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,#e3f2fd,transparent_55%)]" />
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white via-[#f5f8fb] to-[#fef6f4]" />
+
+      <section className="relative overflow-hidden pt-28 pb-20">
+        <div className="absolute inset-0 -z-10 bg-hero-pattern opacity-90" />
+        <div className="absolute inset-0 -z-10 bg-grid opacity-20" />
+        <div className="container relative">
+          <div className="grid gap-16 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+            <div className="space-y-8 text-white">
+              <Badge className="bg-white/15 text-white">Новый дизайн TravelProSchool 2024</Badge>
+              <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
+                Станьте востребованным турагентом с платформой нового поколения
+              </h1>
+              <p className="text-lg text-white/85 lg:text-xl">
+                Живая аналитика, авторские методики и практические симуляции в одном пространстве. Постройте карьеру в туризме с поддержкой наставников TravelPro.
+              </p>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                <Button size="lg" className="gap-2">
+                  Начать обучение
+                  <ArrowRight className="h-5 w-5" />
+                </Button>
+                <Button size="lg" variant="secondary" className="gap-2">
+                  Узнать программу
+                  <Compass className="h-5 w-5" />
+                </Button>
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                {achievements.map((item) => (
+                  <div key={item.label} className="rounded-2xl border border-white/15 bg-white/10 p-4 text-center">
+                    <p className="text-2xl font-semibold lg:text-3xl">{item.value}</p>
+                    <p className="text-sm text-white/70">{item.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <Card className="border-white/20 bg-white/10 p-0 text-white shadow-none backdrop-blur-3xl">
+              <CardContent className="space-y-6 p-8">
+                <div className="relative h-72 overflow-hidden rounded-3xl">
+                  <Image
+                    src="https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?auto=format&fit=crop&w=1200&q=80"
+                    alt="Эмоциональные путешествия"
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-2xl font-semibold">Погружение в индустрию</h3>
+                  <p className="text-sm text-white/75">
+                    Получите доступ к базам поставщиков, шаблонам документов и библиотеке лучших маршрутов TravelPro.
+                  </p>
+                </div>
+                <Separator className="bg-white/10" />
+                <div className="flex items-center gap-3">
+                  <Avatar className="border-white/50">
+                    <AvatarImage src="https://images.unsplash.com/photo-1506898665064-81587b94933a?auto=format&fit=crop&w=160&q=80" />
+                    <AvatarFallback>AG</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-semibold">Александра Голубева</p>
+                    <p className="text-xs text-white/70">Руководитель программы</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="container space-y-12 py-20">
+        <div className="space-y-4 text-center">
+          <Badge variant="secondary" className="mx-auto">Почему TravelProSchool</Badge>
+          <h2 className="text-3xl font-semibold sm:text-4xl">Обучение, которое работает на результат</h2>
+          <p className="section-subtitle">
+            Сочетание живых сессий с экспертами, цифровых тренажёров и карьерного сопровождения. Мы обновили подход, сохранив душу TravelPro.
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {modules.map(({ title, description, icon: Icon }) => (
+            <Card key={title} className="h-full border-border/40 bg-white/95">
+              <CardHeader>
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription className="text-base text-muted-foreground/90">
+                  {description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-4">
+                <ul className="space-y-3 text-sm text-muted-foreground">
+                  <li>• Практические задания и разбор кейсов</li>
+                  <li>• Конспекты и шаблоны для ежедневной работы</li>
+                  <li>• Наставник, который отвечает в течение суток</li>
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-gradient-to-br from-white via-[#f6f9fc] to-[#fef5ef] py-20">
+        <div className="container grid gap-12 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <Badge variant="accent" className="w-fit">Гибридный формат</Badge>
+            <h2 className="text-3xl font-semibold sm:text-4xl">
+              Гибкая программа с живыми практикумами и цифровыми инструментами
+            </h2>
+            <p className="section-subtitle text-left">
+              Осваивайте профессию в комфортном темпе. Каждую неделю — интерактивные практикумы, digital-симуляции и обратная связь от наставников.
+            </p>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <Card className="border-transparent bg-white/80">
+                <CardHeader>
+                  <CardTitle className="text-xl">Иммерсивные мастерские</CardTitle>
+                  <CardDescription>
+                    Работа в малых группах, реальные кейсы TravelPro и защита проектов перед экспертами индустрии.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+              <Card className="border-transparent bg-white/80">
+                <CardHeader>
+                  <CardTitle className="text-xl">Digital-лаборатория</CardTitle>
+                  <CardDescription>
+                    Симуляторы переговоров, библиотека документов и панель аналитики по рынку в вашем личном кабинете.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </div>
+            <Button size="lg" className="gap-2 w-fit">
+              Записаться на демо-урок
+              <ArrowRight className="h-5 w-5" />
+            </Button>
+          </div>
+          <div className="relative">
+            <Card className="overflow-hidden border-border/40 bg-white/95">
+              <CardContent className="space-y-6 p-0">
+                <div className="relative h-72 w-full">
+                  <Image
+                    src="https://images.unsplash.com/photo-1526662092594-e98c1e356d6a?auto=format&fit=crop&w=1200&q=80"
+                    alt="Команда турагентов"
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="space-y-4 px-8 pb-8">
+                  <h3 className="text-2xl font-semibold">Менторская команда TravelPro</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Работайте с практиками рынка: руководителями агентств, экспертами по премиальному и деловому туризму.
+                  </p>
+                  <div className="grid gap-4 sm:grid-cols-3">
+                    {mentors.map((mentor) => (
+                      <div key={mentor.name} className="rounded-2xl border border-border/50 bg-muted/30 p-4 text-center">
+                        <Avatar className="mx-auto h-16 w-16 border-none">
+                          <AvatarImage src={mentor.image} alt={mentor.name} />
+                          <AvatarFallback>{mentor.name.slice(0, 2)}</AvatarFallback>
+                        </Avatar>
+                        <p className="mt-3 text-sm font-semibold">{mentor.name}</p>
+                        <p className="text-xs text-muted-foreground">{mentor.role}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="container space-y-12 py-20">
+        <div className="space-y-4 text-center">
+          <Badge variant="secondary" className="mx-auto">Отзывы выпускников</Badge>
+          <h2 className="text-3xl font-semibold sm:text-4xl">TravelPro помогает расти быстрее</h2>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {testimonials.map((testimonial) => (
+            <Card key={testimonial.name} className="border-border/40 bg-white/95">
+              <CardHeader className="flex-row items-center gap-4 pb-6">
+                <Avatar className="h-14 w-14">
+                  <AvatarImage src={testimonial.image} alt={testimonial.name} />
+                  <AvatarFallback>{testimonial.name.slice(0, 2)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <CardTitle className="text-xl">{testimonial.name}</CardTitle>
+                  <CardDescription className="text-sm text-muted-foreground">
+                    {testimonial.role}
+                  </CardDescription>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 text-base text-muted-foreground">
+                “{testimonial.message}”
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden py-20">
+        <div className="absolute inset-0 -z-10 bg-hero-pattern opacity-95" />
+        <div className="absolute inset-0 -z-10 bg-grid opacity-20" />
+        <div className="container relative grid gap-10 text-white lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <Badge className="bg-white/15 text-white">Готовы к новому уровню?</Badge>
+            <h2 className="text-3xl font-semibold sm:text-4xl">
+              Подключайтесь к TravelProSchool и прокачайте команду за 3 месяца
+            </h2>
+            <p className="text-white/80">
+              Персонализированная дорожная карта, консультации с наставниками и закрытое сообщество турагентов — всё, чтобы ваш бизнес рос увереннее.
+            </p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Button size="lg" className="gap-2">
+                Пройти консультацию
+                <ArrowRight className="h-5 w-5" />
+              </Button>
+              <Button size="lg" variant="outline" className="border-white/60 text-white hover:bg-white/10">
+                Скачать программу курса
+              </Button>
+            </div>
+          </div>
+          <Card className="border-white/20 bg-white/10 text-white shadow-none backdrop-blur-2xl">
+            <CardContent className="space-y-6 p-8">
+              <div className="space-y-3">
+                <h3 className="text-2xl font-semibold">Что входит</h3>
+                <ul className="space-y-3 text-sm text-white/80">
+                  <li>• 12 живых модулей и 30+ онлайн-уроков</li>
+                  <li>• Доступ к библиотеке авторских маршрутов</li>
+                  <li>• Наставник TravelPro и карьерное сопровождение</li>
+                  <li>• Сертификат и помощь в трудоустройстве</li>
+                </ul>
+              </div>
+              <Separator className="bg-white/10" />
+              <div>
+                <p className="text-sm uppercase tracking-wide text-white/60">Следующий поток</p>
+                <p className="text-2xl font-semibold">15 апреля 2024</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/new-design/components/ui/avatar.tsx
+++ b/new-design/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-12 w-12 shrink-0 overflow-hidden rounded-full border border-border/60 bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full object-cover", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary",
+      className
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/new-design/components/ui/badge.tsx
+++ b/new-design/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-transparent px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary/10 text-primary border-primary/20",
+        secondary: "bg-secondary/15 text-secondary border-secondary/20",
+        accent: "bg-accent/10 text-accent border-accent/20",
+        outline: "text-foreground border-border/60",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/new-design/components/ui/button.tsx
+++ b/new-design/components/ui/button.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-lg shadow-secondary/30",
+        outline:
+          "border border-primary/30 text-primary hover:bg-primary/10",
+        ghost: "text-foreground hover:bg-muted",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-11 px-6 py-2",
+        sm: "h-9 px-4",
+        lg: "h-12 px-8 text-base",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/new-design/components/ui/card.tsx
+++ b/new-design/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-3xl border border-border/60 bg-card/80 backdrop-blur-xl text-card-foreground shadow-soft",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-2 p-8 pb-0", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-tight tracking-tight text-2xl", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-8 pt-6", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/new-design/components/ui/separator.tsx
+++ b/new-design/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = false, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border/70",
+      orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/new-design/lib/utils.ts
+++ b/new-design/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/new-design/next-env.d.ts
+++ b/new-design/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/new-design/next.config.mjs
+++ b/new-design/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/new-design/package.json
+++ b/new-design/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "travelproschool-new-design",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-hover-card": "^1.0.7",
+    "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.0.4",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.363.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/new-design/postcss.config.mjs
+++ b/new-design/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/new-design/tailwind.config.ts
+++ b/new-design/tailwind.config.ts
@@ -1,0 +1,64 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "1.5rem",
+      screens: {
+        "2xl": "1280px"
+      }
+    },
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "#2D5A87",
+          foreground: "#F8F9FA"
+        },
+        secondary: {
+          DEFAULT: "#F4A261",
+          foreground: "#1F2933"
+        },
+        accent: {
+          DEFAULT: "#E76F51",
+          foreground: "#FDFCFB"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))"
+      },
+      backgroundImage: {
+        "hero-pattern": "linear-gradient(135deg, rgba(45,90,135,0.88) 0%, rgba(38,70,83,0.92) 50%, rgba(231,111,81,0.8) 100%)"
+      },
+      keyframes: {
+        "fade-up": {
+          "0%": { opacity: "0", transform: "translateY(16px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" }
+        }
+      },
+      animation: {
+        "fade-up": "fade-up 0.6s ease-out forwards"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/new-design/tsconfig.json
+++ b/new-design/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add navigation buttons on the legacy landing page that point to the refreshed experience
- scaffold a modern Next.js 14 project styled with Tailwind and shadcn/ui components for the new design
- implement updated sections, imagery, and content to mirror the original tone with a contemporary layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3cdac108832cad0c9211eda18ec6