### PR TITLE
Add static HTML for new design landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,16 +148,27 @@
                     <a href="contact.html" class="text-dark hover:text-primary transition-colors">Контакты</a>
                 </div>
                 
-                <button class="btn-primary text-white px-6 py-2 rounded-lg font-medium">
-                    Войти
-                </button>
+                <div class="hidden md:flex items-center space-x-3">
+                    <a href="new-design" class="btn-primary text-white px-6 py-2 rounded-lg font-medium inline-flex items-center justify-center shadow-sm">
+                        Перейти на новый дизайн
+                    </a>
+                    <button class="btn-primary text-white px-6 py-2 rounded-lg font-medium">
+                        Войти
+                    </button>
+                </div>
                 
                 <!-- Mobile menu button -->
-                <button class="md:hidden p-2" id="mobile-menu-btn">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                    </svg>
-                </button>
+                <div class="md:hidden flex items-center space-x-2">
+                    <a href="new-design" class="btn-primary text-white px-4 py-2 rounded-lg font-medium inline-flex items-center justify-center shadow-sm text-sm">
+                        Новый дизайн
+                    </a>
+                    <button class="btn-primary text-white px-4 py-2 rounded-lg font-medium text-sm">Войти</button>
+                    <button class="md:hidden p-2" id="mobile-menu-btn">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </button>
+                </div>
             </div>
             
             <!-- Mobile menu -->

--- a/new-design/.eslintrc.json
+++ b/new-design/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/new-design/.gitignore
+++ b/new-design/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+/.next
+/out
+.next
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/new-design/README.md
+++ b/new-design/README.md
@@ -1,0 +1,20 @@
+# TravelProSchool — новый дизайн
+
+Современная версия сайта TravelProSchool на Next.js 14 с компонентами shadcn/ui.
+
+## Запуск проекта
+
+```bash
+cd new-design
+npm install
+npm run dev
+```
+
+Приложение поднимется на `http://localhost:3000`.
+
+## Скрипты
+
+- `npm run dev` — запуск режима разработки.
+- `npm run build` — production-сборка.
+- `npm run start` — запуск production-сборки.
+- `npm run lint` — проверка кода линтером.

--- a/new-design/app/globals.css
+++ b/new-design/app/globals.css
@@ -1,0 +1,57 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 207 49% 36%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 28 87% 67%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 12 77% 55%;
+  --accent-foreground: 0 0% 100%;
+  --destructive: 0 72.2% 50.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 215 20.2% 65.1%;
+  --radius: 0.8rem;
+}
+
+* {
+  @apply border-border;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+  font-feature-settings: "ss01" on, "ss03" on;
+}
+
+.gradient-text {
+  background: linear-gradient(135deg, #F4A261 0%, #E76F51 45%, #F4D35E 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.section-subtitle {
+  @apply text-muted-foreground text-base sm:text-lg max-w-2xl mx-auto;
+}
+
+.shadow-soft {
+  box-shadow: 0 30px 60px -15px rgba(45, 90, 135, 0.25);
+}
+
+@layer utilities {
+  .bg-grid {
+    background-image: linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+}

--- a/new-design/app/layout.tsx
+++ b/new-design/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { Plus_Jakarta_Sans } from "next/font/google";
+import "./globals.css";
+
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin", "cyrillic"],
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  title: "TravelProSchool — Современная платформа обучения турагентов",
+  description:
+    "Обновленная платформа TravelProSchool с интерактивными форматами обучения, экспертной поддержкой и инструментами для карьерного роста в туризме.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ru" suppressHydrationWarning>
+      <body className={jakarta.className}>{children}</body>
+    </html>
+  );
+}

--- a/new-design/app/page.tsx
+++ b/new-design/app/page.tsx
@@ -1,0 +1,326 @@
+import Image from "next/image";
+import { ArrowRight, Compass, LineChart, Map, Users } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
+
+const mentors = [
+  {
+    name: "Анна Громова",
+    role: "Эксперт по премиальным маршрутам",
+    image:
+      "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=256&q=80",
+  },
+  {
+    name: "Михаил Дроздов",
+    role: "Руководитель агентства TravelPro",
+    image:
+      "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=256&q=80",
+  },
+  {
+    name: "Екатерина Лазутина",
+    role: "Специалист по бизнес-туризму",
+    image:
+      "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=256&q=80",
+  },
+];
+
+const achievements = [
+  { value: "8 500+", label: "выпускников по всему миру" },
+  { value: "120", label: "практических кейсов и сценариев" },
+  { value: "45%", label: "средний рост дохода выпускников" },
+];
+
+const modules = [
+  {
+    title: "Стратегия и аналитика",
+    description:
+      "Изучайте современные тренды туризма, анализируйте спрос и формируйте сильные продуктовые линейки.",
+    icon: LineChart,
+  },
+  {
+    title: "Создание маршрутов",
+    description:
+      "Конструируйте путешествия под любой запрос: от семейных до корпоративных с опорой на реальный опыт.",
+    icon: Map,
+  },
+  {
+    title: "Коммуникации с клиентами",
+    description:
+      "Освойте сервисный стандарт TravelPro, научитесь выстраивать долгосрочные отношения и удерживать клиентов.",
+    icon: Users,
+  },
+];
+
+const testimonials = [
+  {
+    name: "Наталья Сафонова",
+    role: "Основатель агентства NataTravel",
+    message:
+      "После курса мы расширили линейку авторских туров и увеличили оборот в 1.8 раза. Особенно помогли практикумы с наставниками.",
+    image:
+      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=160&q=80",
+  },
+  {
+    name: "Игорь Левицкий",
+    role: "Корпоративный менеджер по туризму",
+    message:
+      "Интерактивные симуляторы переговоров с клиентами — это must-have. Теперь команда закрывает заявки быстрее и увереннее.",
+    image:
+      "https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=160&q=80",
+  },
+];
+
+export default function Home() {
+  return (
+    <main className="relative">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,#e3f2fd,transparent_55%)]" />
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white via-[#f5f8fb] to-[#fef6f4]" />
+
+      <section className="relative overflow-hidden pt-28 pb-20">
+        <div className="absolute inset-0 -z-10 bg-hero-pattern opacity-90" />
+        <div className="absolute inset-0 -z-10 bg-grid opacity-20" />
+        <div className="container relative">
+          <div className="grid gap-16 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+            <div className="space-y-8 text-white">
+              <Badge className="bg-white/15 text-white">Новый дизайн TravelProSchool 2024</Badge>
+              <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
+                Станьте востребованным турагентом с платформой нового поколения
+              </h1>
+              <p className="text-lg text-white/85 lg:text-xl">
+                Живая аналитика, авторские методики и практические симуляции в одном пространстве. Постройте карьеру в туризме с поддержкой наставников TravelPro.
+              </p>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                <Button size="lg" className="gap-2">
+                  Начать обучение
+                  <ArrowRight className="h-5 w-5" />
+                </Button>
+                <Button size="lg" variant="secondary" className="gap-2">
+                  Узнать программу
+                  <Compass className="h-5 w-5" />
+                </Button>
+              </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                {achievements.map((item) => (
+                  <div key={item.label} className="rounded-2xl border border-white/15 bg-white/10 p-4 text-center">
+                    <p className="text-2xl font-semibold lg:text-3xl">{item.value}</p>
+                    <p className="text-sm text-white/70">{item.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <Card className="border-white/20 bg-white/10 p-0 text-white shadow-none backdrop-blur-3xl">
+              <CardContent className="space-y-6 p-8">
+                <div className="relative h-72 overflow-hidden rounded-3xl">
+                  <Image
+                    src="https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?auto=format&fit=crop&w=1200&q=80"
+                    alt="Эмоциональные путешествия"
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-2xl font-semibold">Погружение в индустрию</h3>
+                  <p className="text-sm text-white/75">
+                    Получите доступ к базам поставщиков, шаблонам документов и библиотеке лучших маршрутов TravelPro.
+                  </p>
+                </div>
+                <Separator className="bg-white/10" />
+                <div className="flex items-center gap-3">
+                  <Avatar className="border-white/50">
+                    <AvatarImage src="https://images.unsplash.com/photo-1506898665064-81587b94933a?auto=format&fit=crop&w=160&q=80" />
+                    <AvatarFallback>AG</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-semibold">Александра Голубева</p>
+                    <p className="text-xs text-white/70">Руководитель программы</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="container space-y-12 py-20">
+        <div className="space-y-4 text-center">
+          <Badge variant="secondary" className="mx-auto">Почему TravelProSchool</Badge>
+          <h2 className="text-3xl font-semibold sm:text-4xl">Обучение, которое работает на результат</h2>
+          <p className="section-subtitle">
+            Сочетание живых сессий с экспертами, цифровых тренажёров и карьерного сопровождения. Мы обновили подход, сохранив душу TravelPro.
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {modules.map(({ title, description, icon: Icon }) => (
+            <Card key={title} className="h-full border-border/40 bg-white/95">
+              <CardHeader>
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription className="text-base text-muted-foreground/90">
+                  {description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-4">
+                <ul className="space-y-3 text-sm text-muted-foreground">
+                  <li>• Практические задания и разбор кейсов</li>
+                  <li>• Конспекты и шаблоны для ежедневной работы</li>
+                  <li>• Наставник, который отвечает в течение суток</li>
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-gradient-to-br from-white via-[#f6f9fc] to-[#fef5ef] py-20">
+        <div className="container grid gap-12 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <Badge variant="accent" className="w-fit">Гибридный формат</Badge>
+            <h2 className="text-3xl font-semibold sm:text-4xl">
+              Гибкая программа с живыми практикумами и цифровыми инструментами
+            </h2>
+            <p className="section-subtitle text-left">
+              Осваивайте профессию в комфортном темпе. Каждую неделю — интерактивные практикумы, digital-симуляции и обратная связь от наставников.
+            </p>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <Card className="border-transparent bg-white/80">
+                <CardHeader>
+                  <CardTitle className="text-xl">Иммерсивные мастерские</CardTitle>
+                  <CardDescription>
+                    Работа в малых группах, реальные кейсы TravelPro и защита проектов перед экспертами индустрии.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+              <Card className="border-transparent bg-white/80">
+                <CardHeader>
+                  <CardTitle className="text-xl">Digital-лаборатория</CardTitle>
+                  <CardDescription>
+                    Симуляторы переговоров, библиотека документов и панель аналитики по рынку в вашем личном кабинете.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </div>
+            <Button size="lg" className="gap-2 w-fit">
+              Записаться на демо-урок
+              <ArrowRight className="h-5 w-5" />
+            </Button>
+          </div>
+          <div className="relative">
+            <Card className="overflow-hidden border-border/40 bg-white/95">
+              <CardContent className="space-y-6 p-0">
+                <div className="relative h-72 w-full">
+                  <Image
+                    src="https://images.unsplash.com/photo-1526662092594-e98c1e356d6a?auto=format&fit=crop&w=1200&q=80"
+                    alt="Команда турагентов"
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="space-y-4 px-8 pb-8">
+                  <h3 className="text-2xl font-semibold">Менторская команда TravelPro</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Работайте с практиками рынка: руководителями агентств, экспертами по премиальному и деловому туризму.
+                  </p>
+                  <div className="grid gap-4 sm:grid-cols-3">
+                    {mentors.map((mentor) => (
+                      <div key={mentor.name} className="rounded-2xl border border-border/50 bg-muted/30 p-4 text-center">
+                        <Avatar className="mx-auto h-16 w-16 border-none">
+                          <AvatarImage src={mentor.image} alt={mentor.name} />
+                          <AvatarFallback>{mentor.name.slice(0, 2)}</AvatarFallback>
+                        </Avatar>
+                        <p className="mt-3 text-sm font-semibold">{mentor.name}</p>
+                        <p className="text-xs text-muted-foreground">{mentor.role}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="container space-y-12 py-20">
+        <div className="space-y-4 text-center">
+          <Badge variant="secondary" className="mx-auto">Отзывы выпускников</Badge>
+          <h2 className="text-3xl font-semibold sm:text-4xl">TravelPro помогает расти быстрее</h2>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {testimonials.map((testimonial) => (
+            <Card key={testimonial.name} className="border-border/40 bg-white/95">
+              <CardHeader className="flex-row items-center gap-4 pb-6">
+                <Avatar className="h-14 w-14">
+                  <AvatarImage src={testimonial.image} alt={testimonial.name} />
+                  <AvatarFallback>{testimonial.name.slice(0, 2)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <CardTitle className="text-xl">{testimonial.name}</CardTitle>
+                  <CardDescription className="text-sm text-muted-foreground">
+                    {testimonial.role}
+                  </CardDescription>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 text-base text-muted-foreground">
+                “{testimonial.message}”
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="relative overflow-hidden py-20">
+        <div className="absolute inset-0 -z-10 bg-hero-pattern opacity-95" />
+        <div className="absolute inset-0 -z-10 bg-grid opacity-20" />
+        <div className="container relative grid gap-10 text-white lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+          <div className="space-y-6">
+            <Badge className="bg-white/15 text-white">Готовы к новому уровню?</Badge>
+            <h2 className="text-3xl font-semibold sm:text-4xl">
+              Подключайтесь к TravelProSchool и прокачайте команду за 3 месяца
+            </h2>
+            <p className="text-white/80">
+              Персонализированная дорожная карта, консультации с наставниками и закрытое сообщество турагентов — всё, чтобы ваш бизнес рос увереннее.
+            </p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Button size="lg" className="gap-2">
+                Пройти консультацию
+                <ArrowRight className="h-5 w-5" />
+              </Button>
+              <Button size="lg" variant="outline" className="border-white/60 text-white hover:bg-white/10">
+                Скачать программу курса
+              </Button>
+            </div>
+          </div>
+          <Card className="border-white/20 bg-white/10 text-white shadow-none backdrop-blur-2xl">
+            <CardContent className="space-y-6 p-8">
+              <div className="space-y-3">
+                <h3 className="text-2xl font-semibold">Что входит</h3>
+                <ul className="space-y-3 text-sm text-white/80">
+                  <li>• 12 живых модулей и 30+ онлайн-уроков</li>
+                  <li>• Доступ к библиотеке авторских маршрутов</li>
+                  <li>• Наставник TravelPro и карьерное сопровождение</li>
+                  <li>• Сертификат и помощь в трудоустройстве</li>
+                </ul>
+              </div>
+              <Separator className="bg-white/10" />
+              <div>
+                <p className="text-sm uppercase tracking-wide text-white/60">Следующий поток</p>
+                <p className="text-2xl font-semibold">15 апреля 2024</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/new-design/components/ui/avatar.tsx
+++ b/new-design/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-12 w-12 shrink-0 overflow-hidden rounded-full border border-border/60 bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full object-cover", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary",
+      className
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/new-design/components/ui/badge.tsx
+++ b/new-design/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-transparent px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary/10 text-primary border-primary/20",
+        secondary: "bg-secondary/15 text-secondary border-secondary/20",
+        accent: "bg-accent/10 text-accent border-accent/20",
+        outline: "text-foreground border-border/60",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/new-design/components/ui/button.tsx
+++ b/new-design/components/ui/button.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-lg shadow-secondary/30",
+        outline:
+          "border border-primary/30 text-primary hover:bg-primary/10",
+        ghost: "text-foreground hover:bg-muted",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-11 px-6 py-2",
+        sm: "h-9 px-4",
+        lg: "h-12 px-8 text-base",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/new-design/components/ui/card.tsx
+++ b/new-design/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-3xl border border-border/60 bg-card/80 backdrop-blur-xl text-card-foreground shadow-soft",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-2 p-8 pb-0", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-tight tracking-tight text-2xl", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-8 pt-6", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/new-design/components/ui/separator.tsx
+++ b/new-design/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = false, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border/70",
+      orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/new-design/index.html
+++ b/new-design/index.html
@@ -1,0 +1,681 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TravelProSchool — новый дизайн</title>
+  <meta name="description" content="Современная программа TravelProSchool с живыми наставниками, digital-инструментами и карьерным сопровождением." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Manrope:wght@500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ["Inter", "system-ui", "sans-serif"],
+            display: ["Manrope", "Inter", "sans-serif"],
+          },
+          colors: {
+            background: "#f7f9fc",
+            foreground: "#0f172a",
+            primary: {
+              DEFAULT: "#2663eb",
+              foreground: "#ffffff",
+            },
+            secondary: {
+              DEFAULT: "#f1f5f9",
+              foreground: "#0f172a",
+            },
+            accent: {
+              DEFAULT: "#f97316",
+              foreground: "#0f172a",
+            },
+            muted: {
+              DEFAULT: "#e2e8f0",
+              foreground: "#64748b",
+            },
+            border: "rgba(148, 163, 184, 0.35)",
+            card: "rgba(255, 255, 255, 0.88)",
+          },
+          boxShadow: {
+            soft: "0 20px 45px -20px rgba(37, 99, 235, 0.45)",
+            subtle: "0 18px 35px -22px rgba(15, 23, 42, 0.35)",
+          },
+          backgroundImage: {
+            "hero-pattern": "radial-gradient(circle at top left, rgba(37,99,235,0.18), transparent 55%), radial-gradient(circle at top right, rgba(14,165,233,0.18), transparent 60%)",
+            "mesh": "linear-gradient(145deg, rgba(255,255,255,0.45), rgba(37,99,235,0.12))",
+            "grid": "linear-gradient(rgba(15,23,42,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(15,23,42,0.05) 1px, transparent 1px)",
+          },
+          gridTemplateColumns: {
+            feature: "repeat(auto-fit, minmax(240px, 1fr))",
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    body {
+      font-feature-settings: "liga" 1, "kern" 1;
+      font-family: "Inter", system-ui, sans-serif;
+      background-color: #f7f9fc;
+      color: #0f172a;
+    }
+    .bg-grid {
+      background-size: 44px 44px;
+    }
+    .glass-card {
+      backdrop-filter: blur(20px);
+    }
+    .shadcn-card {
+      border-radius: 28px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      background: rgba(255, 255, 255, 0.92);
+      box-shadow: 0 18px 45px -28px rgba(15, 23, 42, 0.45);
+    }
+    .shadcn-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 9999px;
+      font-weight: 600;
+      transition: all 0.25s ease;
+    }
+    .shadcn-button.primary {
+      background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+      color: white;
+      box-shadow: 0 20px 35px -18px rgba(37, 99, 235, 0.65);
+    }
+    .shadcn-button.primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 24px 50px -18px rgba(37, 99, 235, 0.75);
+    }
+    .shadcn-button.secondary {
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      color: #1e293b;
+    }
+    .shadcn-button.secondary:hover {
+      background: rgba(248, 250, 252, 1);
+      transform: translateY(-1px);
+    }
+    .stat-gradient {
+      background: linear-gradient(135deg, rgba(37,99,235,0.12), rgba(59,130,246,0.22));
+    }
+    .highlight-ring {
+      position: relative;
+    }
+    .highlight-ring::before {
+      content: "";
+      position: absolute;
+      inset: -1.75rem;
+      border-radius: 36px;
+      background: linear-gradient(135deg, rgba(59,130,246,0.32), rgba(14,165,233,0.32));
+      opacity: 0.25;
+      filter: blur(40px);
+      z-index: -1;
+    }
+    .timeline::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      width: 2px;
+      margin: auto;
+      background: linear-gradient(180deg, rgba(37,99,235,0), rgba(37,99,235,0.35), rgba(59,130,246,0));
+    }
+    .faq-item button {
+      width: 100%;
+      text-align: left;
+    }
+    .faq-answer {
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden;
+      transition: all 0.35s ease;
+    }
+    .faq-item.open .faq-answer {
+      max-height: 320px;
+      opacity: 1;
+      margin-top: 0.75rem;
+    }
+  </style>
+</head>
+<body class="antialiased">
+  <div class="relative overflow-hidden">
+    <div class="absolute inset-0 bg-hero-pattern opacity-95 pointer-events-none"></div>
+    <div class="absolute inset-0 bg-grid opacity-30 pointer-events-none"></div>
+    <header class="relative">
+      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-6 sm:px-6 lg:px-8">
+        <a href="../index.html" class="flex items-center gap-3 text-lg font-semibold text-slate-800">
+          <span class="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/90 shadow-soft">
+            <svg class="h-6 w-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 7l9-4 9 4-9 4-9-4z" />
+              <path d="M3 17l9 4 9-4" />
+              <path d="M3 12l9 4 9-4" />
+            </svg>
+          </span>
+          TravelProSchool
+        </a>
+        <nav class="hidden items-center gap-8 text-sm font-medium text-slate-600 md:flex">
+          <a class="transition hover:text-primary" href="#program">Программа</a>
+          <a class="transition hover:text-primary" href="#mentors">Наставники</a>
+          <a class="transition hover:text-primary" href="#tools">Инструменты</a>
+          <a class="transition hover:text-primary" href="#faq">FAQ</a>
+        </nav>
+        <div class="hidden items-center gap-3 md:flex">
+          <a class="shadcn-button secondary px-5 py-2 text-sm" href="#pricing">Пакеты</a>
+          <a class="shadcn-button primary px-6 py-2.5 text-sm" href="#enroll">Присоединиться</a>
+        </div>
+        <button id="mobile-toggle" class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 text-slate-600 shadow-soft transition md:hidden">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="4" y1="6" x2="20" y2="6" />
+            <line x1="4" y1="12" x2="20" y2="12" />
+            <line x1="4" y1="18" x2="20" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <div id="mobile-menu" class="mx-4 hidden flex-col gap-3 rounded-3xl border border-white/50 bg-white/90 p-5 text-sm font-medium text-slate-600 shadow-soft md:hidden">
+        <a class="rounded-2xl px-4 py-2 transition hover:bg-slate-100" href="#program">Программа</a>
+        <a class="rounded-2xl px-4 py-2 transition hover:bg-slate-100" href="#mentors">Наставники</a>
+        <a class="rounded-2xl px-4 py-2 transition hover:bg-slate-100" href="#tools">Инструменты</a>
+        <a class="rounded-2xl px-4 py-2 transition hover:bg-slate-100" href="#faq">FAQ</a>
+        <a class="shadcn-button secondary px-4 py-2" href="#pricing">Пакеты</a>
+        <a class="shadcn-button primary px-4 py-2" href="#enroll">Старт программы</a>
+      </div>
+    </header>
+
+    <main class="relative">
+      <section class="relative overflow-hidden pt-20 pb-24 sm:pt-28">
+        <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.72),rgba(37,99,235,0.18))]"></div>
+        <div class="relative mx-auto grid max-w-6xl items-center gap-14 px-4 sm:px-6 lg:grid-cols-[1.1fr,0.9fr] lg:px-8">
+          <div class="space-y-8 text-slate-50">
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/15 px-4 py-1 text-sm font-medium uppercase tracking-wide text-white/90 shadow-soft">
+              Новый дизайн TravelProSchool · 2024
+            </span>
+            <h1 class="font-display text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+              Переосмысленная платформа для обучения турагентов
+            </h1>
+            <p class="max-w-xl text-lg text-white/85 lg:text-xl">
+              Создана на основе реальных кейсов и digital-инструментов TravelPro. Обучение, которое превращает опыт в бизнес-результат уже во время программы.
+            </p>
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <a href="#enroll" class="shadcn-button primary px-7 py-3 text-base">
+                Начать обучение
+                <svg class="ml-2 h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 12h14"></path>
+                  <path d="M12 5l7 7-7 7"></path>
+                </svg>
+              </a>
+              <a href="#program" class="shadcn-button secondary px-6 py-3 text-base">
+                Узнать программу
+                <svg class="ml-2 h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 16v-4" />
+                  <path d="M12 8h.01" />
+                </svg>
+              </a>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-3">
+              <div class="rounded-2xl border border-white/20 bg-white/10 p-5 text-center">
+                <p class="text-3xl font-semibold text-white">8 500+</p>
+                <p class="text-sm text-white/70">выпускников по всему миру</p>
+              </div>
+              <div class="rounded-2xl border border-white/20 bg-white/10 p-5 text-center">
+                <p class="text-3xl font-semibold text-white">120</p>
+                <p class="text-sm text-white/70">практических кейсов и сценариев</p>
+              </div>
+              <div class="rounded-2xl border border-white/20 bg-white/10 p-5 text-center">
+                <p class="text-3xl font-semibold text-white">45%</p>
+                <p class="text-sm text-white/70">рост дохода выпускников</p>
+              </div>
+            </div>
+          </div>
+          <div class="relative">
+            <div class="highlight-ring"></div>
+            <div class="glass-card relative overflow-hidden rounded-[32px] border border-white/30 bg-white/15 shadow-soft">
+              <img class="h-80 w-full object-cover" src="https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?auto=format&fit=crop&w=1200&q=80" alt="Погружение в индустрию" />
+              <div class="space-y-5 p-8 text-white">
+                <div>
+                  <h3 class="text-2xl font-semibold">Погружение в индустрию</h3>
+                  <p class="text-white/70">Доступ к базе проверенных партнёров, шаблонам договоров и библиотеке авторских маршрутов TravelPro.</p>
+                </div>
+                <div class="flex items-center gap-3">
+                  <span class="flex h-12 w-12 items-center justify-center rounded-full border border-white/60 bg-white/20">
+                    <img class="h-12 w-12 rounded-full object-cover" src="https://images.unsplash.com/photo-1506898665064-81587b94933a?auto=format&fit=crop&w=160&q=80" alt="Александра Голубева" />
+                  </span>
+                  <div>
+                    <p class="text-sm font-semibold">Александра Голубева</p>
+                    <p class="text-xs text-white/70">Руководитель программы</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="program" class="relative py-24">
+        <div class="mx-auto flex max-w-5xl flex-col items-center gap-6 px-4 text-center sm:px-6">
+          <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">ПОЧЕМУ TRAVELPROSCHOOL</span>
+          <h2 class="font-display text-3xl font-semibold sm:text-4xl">Обучение, которое работает на результат</h2>
+          <p class="max-w-3xl text-base text-slate-600 sm:text-lg">
+            Сочетание живых сессий с экспертами, цифровых тренажёров и карьерного сопровождения. Мы обновили подход, сохранив душу TravelPro.
+          </p>
+        </div>
+        <div class="mx-auto mt-16 grid max-w-6xl gap-6 px-4 sm:px-6 lg:grid-cols-3 lg:px-8">
+          <article class="shadcn-card flex flex-col gap-4 p-7">
+            <span class="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-100 text-primary">
+              <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 3h7l2 3h9v13H3z" />
+              </svg>
+            </span>
+            <h3 class="text-xl font-semibold">Стратегия и аналитика</h3>
+            <p class="text-sm text-slate-600">Актуальные тренды туризма, динамика спроса и построение продуктовых линеек, которые выделяют ваше агентство.</p>
+            <ul class="mt-2 space-y-2 text-sm text-slate-500">
+              <li>• Практические задания и разбор кейсов</li>
+              <li>• Дашборды с аналитикой TravelPro</li>
+              <li>• Наставник, который отвечает в течение суток</li>
+            </ul>
+          </article>
+          <article class="shadcn-card flex flex-col gap-4 p-7">
+            <span class="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-100 text-primary">
+              <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 11l18-5-5 18-4-9-9-4z" />
+              </svg>
+            </span>
+            <h3 class="text-xl font-semibold">Создание маршрутов</h3>
+            <p class="text-sm text-slate-600">Конструируйте путешествия под любой запрос — от семейных экспедиций до корпоративных программ.</p>
+            <ul class="mt-2 space-y-2 text-sm text-slate-500">
+              <li>• Библиотека авторских туров TravelPro</li>
+              <li>• Шаблоны коммуникации и сметы</li>
+              <li>• Воркшопы с экспертами индустрии</li>
+            </ul>
+          </article>
+          <article class="shadcn-card flex flex-col gap-4 p-7">
+            <span class="flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-100 text-primary">
+              <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 7a4 4 0 01-8 0" />
+                <path d="M5 21h14l-2-7H7l-2 7z" />
+              </svg>
+            </span>
+            <h3 class="text-xl font-semibold">Коммуникации с клиентами</h3>
+            <p class="text-sm text-slate-600">Освойте фирменный сервис TravelPro, выстраивайте долгосрочные отношения и удерживайте клиентов.</p>
+            <ul class="mt-2 space-y-2 text-sm text-slate-500">
+              <li>• Скрипты и голосовые симуляции</li>
+              <li>• Поддержка карьерного консультанта</li>
+              <li>• CRM-шаблоны и чек-листы</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="tools" class="relative overflow-hidden bg-gradient-to-br from-white via-[#f6f9fc] to-[#fef5ef] py-24">
+        <div class="mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-[1.05fr,0.95fr] lg:px-8">
+          <div class="space-y-6">
+            <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Гибридный формат</span>
+            <h2 class="font-display text-3xl font-semibold sm:text-4xl">Живые практикумы и цифровые инструменты</h2>
+            <p class="text-base text-slate-600 sm:text-lg">Осваивайте профессию в комфортном темпе. Каждую неделю — интерактивные практикумы, digital-симуляции и обратная связь от наставников.</p>
+            <div class="grid gap-5 sm:grid-cols-2">
+              <div class="shadcn-card border border-blue-100 bg-white/95 p-6">
+                <h3 class="text-lg font-semibold">Иммерсивные мастерские</h3>
+                <p class="mt-2 text-sm text-slate-600">Сессии в VR-студии TravelPro, где отрабатываются сложные сценарии общения с клиентами.</p>
+                <ul class="mt-3 space-y-2 text-sm text-slate-500">
+                  <li>• Разбор диалогов и обратная связь</li>
+                  <li>• Настройка сервисных стандартов</li>
+                </ul>
+              </div>
+              <div class="shadcn-card border border-blue-100 bg-white/95 p-6">
+                <h3 class="text-lg font-semibold">Digital-панель</h3>
+                <p class="mt-2 text-sm text-slate-600">Личный кабинет с шаблонами договоров, калькуляторами маржинальности и календарём поставщиков.</p>
+                <ul class="mt-3 space-y-2 text-sm text-slate-500">
+                  <li>• Сравнение тарифов онлайн</li>
+                  <li>• Интеграция с CRM и Telegram-ботом</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="relative">
+            <div class="shadcn-card relative overflow-hidden p-8">
+              <div class="rounded-[32px] bg-slate-900 p-8 text-white shadow-subtle">
+                <div class="flex items-center justify-between">
+                  <div>
+                    <p class="text-sm uppercase tracking-[0.3em] text-white/60">Live панель</p>
+                    <h3 class="mt-3 text-2xl font-semibold">Индикаторы прогресса</h3>
+                  </div>
+                  <span class="rounded-full bg-white/15 px-4 py-1 text-xs text-white/80">В реальном времени</span>
+                </div>
+                <div class="mt-6 grid gap-6 md:grid-cols-2">
+                  <div class="rounded-2xl bg-white/10 p-4">
+                    <p class="text-sm text-white/70">План продаж</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">+38%</p>
+                    <p class="text-xs text-emerald-300">за последние 4 недели</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/10 p-4">
+                    <p class="text-sm text-white/70">Сделки воронки</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">27</p>
+                    <p class="text-xs text-white/60">готовы к закрытию</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/10 p-4">
+                    <p class="text-sm text-white/70">Удовлетворённость</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">97%</p>
+                    <p class="text-xs text-white/60">средняя оценка клиентов</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/10 p-4">
+                    <p class="text-sm text-white/70">Команда</p>
+                    <p class="mt-2 text-3xl font-semibold text-white">14</p>
+                    <p class="text-xs text-white/60">активных наставников</p>
+                  </div>
+                </div>
+                <div class="mt-6 rounded-2xl bg-white/10 p-4">
+                  <p class="text-sm text-white/70">Следующий практикум</p>
+                  <div class="mt-2 flex items-center justify-between">
+                    <p class="text-lg font-semibold text-white">Авторские туры Premium</p>
+                    <span class="rounded-full bg-white/20 px-3 py-1 text-xs text-white/75">12 апреля · 19:00 (MSK)</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="mentors" class="relative py-24">
+        <div class="mx-auto flex max-w-5xl flex-col items-center gap-6 px-4 text-center sm:px-6">
+          <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Команда</span>
+          <h2 class="font-display text-3xl font-semibold sm:text-4xl">Наставники и кураторы TravelPro</h2>
+          <p class="max-w-3xl text-base text-slate-600 sm:text-lg">Работаете с лидерами индустрии: каждый модуль сопровождается персональным куратором и еженедельными консультациями в малых группах.</p>
+        </div>
+        <div class="mx-auto mt-14 grid max-w-6xl gap-6 px-4 sm:px-6 md:grid-cols-3 lg:px-8">
+          <div class="shadcn-card flex flex-col items-center gap-4 p-8 text-center">
+            <img class="h-24 w-24 rounded-3xl object-cover" src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=256&q=80" alt="Анна Громова" />
+            <div>
+              <h3 class="text-lg font-semibold">Анна Громова</h3>
+              <p class="text-sm text-slate-500">Эксперт по премиальным маршрутам</p>
+            </div>
+            <p class="text-sm text-slate-600">Авторская методика построения luxury-пакетов и партнерская сеть в 26 странах.</p>
+          </div>
+          <div class="shadcn-card flex flex-col items-center gap-4 p-8 text-center">
+            <img class="h-24 w-24 rounded-3xl object-cover" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=256&q=80" alt="Михаил Дроздов" />
+            <div>
+              <h3 class="text-lg font-semibold">Михаил Дроздов</h3>
+              <p class="text-sm text-slate-500">Руководитель агентства TravelPro</p>
+            </div>
+            <p class="text-sm text-slate-600">Ведёт модуль по систематизации бизнеса и построению отдела продаж.</p>
+          </div>
+          <div class="shadcn-card flex flex-col items-center gap-4 p-8 text-center">
+            <img class="h-24 w-24 rounded-3xl object-cover" src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=256&q=80" alt="Екатерина Лазутина" />
+            <div>
+              <h3 class="text-lg font-semibold">Екатерина Лазутина</h3>
+              <p class="text-sm text-slate-500">Специалист по бизнес-туризму</p>
+            </div>
+            <p class="text-sm text-slate-600">Наставник по работе с корпоративными клиентами и запуску MICE-направления.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="relative py-24">
+        <div class="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:px-8">
+          <div class="space-y-6">
+            <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Отзывы</span>
+            <h2 class="font-display text-3xl font-semibold sm:text-4xl">Истории выпускников</h2>
+            <p class="text-base text-slate-600 sm:text-lg">Реальные кейсы роста: от запуска авторских туров до корпоративных контрактов с топ-компаниями.</p>
+            <div class="space-y-4">
+              <div class="shadcn-card flex gap-4 p-6">
+                <img class="h-12 w-12 rounded-2xl object-cover" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=160&q=80" alt="Наталья Сафонова" />
+                <div>
+                  <p class="text-sm font-semibold">Наталья Сафонова</p>
+                  <p class="text-xs text-slate-500">Основатель агентства NataTravel</p>
+                  <p class="mt-3 text-sm text-slate-600">«После курса расширили линейку авторских туров и увеличили оборот в 1.8 раза. Практикумы с наставниками — мощный инструмент принятия решений».</p>
+                </div>
+              </div>
+              <div class="shadcn-card flex gap-4 p-6">
+                <img class="h-12 w-12 rounded-2xl object-cover" src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=160&q=80" alt="Игорь Левицкий" />
+                <div>
+                  <p class="text-sm font-semibold">Игорь Левицкий</p>
+                  <p class="text-xs text-slate-500">Корпоративный менеджер по туризму</p>
+                  <p class="mt-3 text-sm text-slate-600">«Интерактивные симуляторы переговоров — must-have. Команда закрывает заявки быстрее и увереннее».</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="shadcn-card space-y-6 p-8">
+            <h3 class="text-xl font-semibold">Как это происходит</h3>
+            <div class="relative timeline space-y-6 pl-6">
+              <div class="relative rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <span class="absolute -left-3 top-5 h-3.5 w-3.5 rounded-full border-2 border-white bg-blue-500"></span>
+                <p class="text-sm font-semibold text-primary">Неделя 1–2</p>
+                <p class="mt-1 text-sm text-slate-600">Диагностика текущей модели, построение дорожной карты роста и подбор наставника.</p>
+              </div>
+              <div class="relative rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <span class="absolute -left-3 top-5 h-3.5 w-3.5 rounded-full border-2 border-white bg-blue-500"></span>
+                <p class="text-sm font-semibold text-primary">Неделя 3–6</p>
+                <p class="mt-1 text-sm text-slate-600">Практикумы и внедрение инструментов: CRM, калькуляторы маржинальности и шаблоны коммуникаций.</p>
+              </div>
+              <div class="relative rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <span class="absolute -left-3 top-5 h-3.5 w-3.5 rounded-full border-2 border-white bg-blue-500"></span>
+                <p class="text-sm font-semibold text-primary">Неделя 7–10</p>
+                <p class="mt-1 text-sm text-slate-600">Работа над кейсом, карьерные консультации и подготовка к сертификации TravelPro.</p>
+              </div>
+            </div>
+            <div class="rounded-2xl border border-blue-100 bg-blue-50/50 p-6">
+              <p class="text-sm font-semibold text-primary">97% выпускников</p>
+              <p class="mt-2 text-sm text-slate-600">получают job-offer или растят выручку в течение трёх месяцев после завершения программы.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="pricing" class="relative overflow-hidden bg-slate-900 py-24 text-white">
+        <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.45),transparent_70%)]"></div>
+        <div class="relative mx-auto flex max-w-5xl flex-col items-center gap-6 px-4 text-center sm:px-6">
+          <span class="rounded-full border border-white/30 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/80">Пакеты</span>
+          <h2 class="font-display text-3xl font-semibold sm:text-4xl">Выберите формат обучения</h2>
+          <p class="max-w-3xl text-base text-white/80 sm:text-lg">Каждый пакет включает доступ к digital-панели, библиотеке материалов и чатам сообщества.</p>
+        </div>
+        <div class="relative mx-auto mt-16 grid max-w-6xl gap-6 px-4 sm:px-6 lg:grid-cols-3 lg:px-8">
+          <div class="shadcn-card flex flex-col gap-5 bg-white/95 p-8 text-left text-slate-900">
+            <p class="text-sm font-semibold text-blue-500">Старт</p>
+            <h3 class="text-2xl font-semibold">49 900 ₽</h3>
+            <p class="text-sm text-slate-600">Для тех, кто начинает карьеру турагента и хочет освоить стандарты TravelPro.</p>
+            <ul class="space-y-2 text-sm text-slate-600">
+              <li>• 3 месяца обучения и практикумов</li>
+              <li>• Наставник и групповая обратная связь</li>
+              <li>• 30+ шаблонов и чек-листов</li>
+            </ul>
+            <a href="#enroll" class="shadcn-button secondary px-5 py-2 text-sm">Выбрать</a>
+          </div>
+          <div class="shadcn-card flex flex-col gap-5 border-2 border-blue-500 bg-white p-8 text-left text-slate-900 shadow-soft">
+            <p class="inline-flex w-fit items-center gap-2 rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-600">
+              Популярный
+              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+            </p>
+            <h3 class="text-2xl font-semibold">89 900 ₽</h3>
+            <p class="text-sm text-slate-600">Для практикующих специалистов: углублённые симуляции и доступ к клубу партнёров.</p>
+            <ul class="space-y-2 text-sm text-slate-600">
+              <li>• Индивидуальные консультации 1:1</li>
+              <li>• Digital-панель с аналитикой и CRM</li>
+              <li>• Подготовка к сертификации TravelPro</li>
+            </ul>
+            <a href="#enroll" class="shadcn-button primary px-5 py-2 text-sm">Записаться</a>
+          </div>
+          <div class="shadcn-card flex flex-col gap-5 bg-white/95 p-8 text-left text-slate-900">
+            <p class="text-sm font-semibold text-blue-500">Корпоратив</p>
+            <h3 class="text-2xl font-semibold">129 900 ₽</h3>
+            <p class="text-sm text-slate-600">Для агентств и отделов туризма, которым важно стандартизировать процессы команды.</p>
+            <ul class="space-y-2 text-sm text-slate-600">
+              <li>• Настройка CRM и внутренних процессов</li>
+              <li>• Воркшопы для всей команды</li>
+              <li>• Доступ к внутреннему Job Board TravelPro</li>
+            </ul>
+            <a href="#enroll" class="shadcn-button secondary px-5 py-2 text-sm">Связаться</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="enroll" class="relative py-24">
+        <div class="mx-auto max-w-5xl rounded-[40px] border border-blue-100 bg-white/95 p-10 text-center shadow-soft">
+          <div class="mx-auto flex max-w-3xl flex-col items-center gap-4">
+            <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Готовы стартовать?</span>
+            <h2 class="font-display text-3xl font-semibold sm:text-4xl">Присоединяйтесь к TravelProSchool сейчас</h2>
+            <p class="text-base text-slate-600 sm:text-lg">Заполните короткую форму, и куратор программы подберёт стартовое сопровождение и предложит удобный график занятий.</p>
+          </div>
+          <form class="mt-10 grid gap-4 sm:grid-cols-2">
+            <div class="text-left">
+              <label class="block text-sm font-medium text-slate-600">Имя</label>
+              <input required type="text" class="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" placeholder="Как к вам обращаться" />
+            </div>
+            <div class="text-left">
+              <label class="block text-sm font-medium text-slate-600">Email</label>
+              <input required type="email" class="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" placeholder="name@example.com" />
+            </div>
+            <div class="text-left">
+              <label class="block text-sm font-medium text-slate-600">Опыт в туризме</label>
+              <select class="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100">
+                <option>Начинаю карьеру</option>
+                <option>Работаю 1–3 года</option>
+                <option>5+ лет в индустрии</option>
+                <option>Развиваю агентство</option>
+              </select>
+            </div>
+            <div class="text-left">
+              <label class="block text-sm font-medium text-slate-600">Цель</label>
+              <select class="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100">
+                <option>Получить профессию турагента</option>
+                <option>Вырастить продажи текущего агентства</option>
+                <option>Найти новых корпоративных клиентов</option>
+                <option>Внедрить новые сервисы</option>
+              </select>
+            </div>
+            <div class="sm:col-span-2 text-left">
+              <label class="block text-sm font-medium text-slate-600">Комментарии</label>
+              <textarea rows="3" class="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" placeholder="Расскажите, что для вас важно"></textarea>
+            </div>
+            <div class="sm:col-span-2 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <label class="flex items-center gap-2 text-sm text-slate-500">
+                <input type="checkbox" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-300" checked />
+                Я согласен на обработку персональных данных
+              </label>
+              <button type="submit" class="shadcn-button primary px-8 py-3 text-base">Отправить заявку</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section id="faq" class="relative py-24">
+        <div class="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.9fr,1.1fr] lg:px-8">
+          <div class="space-y-6">
+            <span class="rounded-full border border-slate-200 bg-white px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">FAQ</span>
+            <h2 class="font-display text-3xl font-semibold sm:text-4xl">Часто задаваемые вопросы</h2>
+            <p class="text-base text-slate-600 sm:text-lg">Если у вас остались вопросы — оставьте заявку, и мы свяжемся, чтобы рассказать обо всех деталях программы.</p>
+            <div class="rounded-3xl border border-blue-100 bg-blue-50/60 p-6">
+              <p class="text-sm font-semibold text-blue-600">Поддержка 24/7</p>
+              <p class="mt-2 text-sm text-slate-600">Мы сопровождаем вас на протяжении всей программы и после выпуска — чат с наставником и карьерным консультантом не закрывается.</p>
+            </div>
+          </div>
+          <div class="space-y-4">
+            <div class="faq-item rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+              <button class="flex items-center justify-between text-left text-base font-semibold text-slate-700">
+                Сколько длится программа?
+                <svg class="h-5 w-5 transition" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              </button>
+              <div class="faq-answer text-sm text-slate-600">
+                Полная программа рассчитана на 10 недель. Можно проходить быстрее за счёт индивидуальных сессий и доступа к материалам on-demand.
+              </div>
+            </div>
+            <div class="faq-item rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+              <button class="flex items-center justify-between text-left text-base font-semibold text-slate-700">
+                Какие требования к участникам?
+                <svg class="h-5 w-5 transition" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              </button>
+              <div class="faq-answer text-sm text-slate-600">
+                Достаточно базовой компьютерной грамотности и интереса к индустрии туризма. Для корпоративных пакетов потребуется доступ к CRM.
+              </div>
+            </div>
+            <div class="faq-item rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+              <button class="flex items-center justify-between text-left text-base font-semibold text-slate-700">
+                Предоставляете ли вы сертификат?
+                <svg class="h-5 w-5 transition" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              </button>
+              <div class="faq-answer text-sm text-slate-600">
+                Да, выпускники получают сертификат TravelProSchool и рекомендации. Лучшие студенты попадают в закрытый клуб партнёров.
+              </div>
+            </div>
+            <div class="faq-item rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+              <button class="flex items-center justify-between text-left text-base font-semibold text-slate-700">
+                Можно ли вернуть деньги?
+                <svg class="h-5 w-5 transition" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              </button>
+              <div class="faq-answer text-sm text-slate-600">
+                В течение первых 14 дней действует гарантия возврата при условии выполнения стартовых заданий и присутствия на вводных сессиях.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="relative border-t border-slate-200/70 bg-white/90 py-12">
+      <div class="mx-auto grid max-w-6xl gap-8 px-4 text-sm text-slate-500 sm:px-6 lg:grid-cols-[1.2fr,0.8fr] lg:px-8">
+        <div class="space-y-4">
+          <div class="flex items-center gap-3 text-lg font-semibold text-slate-800">
+            <span class="flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-900 text-white">TP</span>
+            TravelProSchool
+          </div>
+          <p class="max-w-md text-sm text-slate-500">Обучаем будущих лидеров туристической индустрии. TravelProSchool объединяет экспертов, технологические инструменты и живые сообщества.</p>
+          <p class="text-xs text-slate-400">© 2024 TravelProSchool. Все права защищены.</p>
+        </div>
+        <div class="grid gap-8 sm:grid-cols-2">
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700">Контакты</h4>
+            <ul class="mt-3 space-y-2 text-sm text-slate-500">
+              <li>support@travelproschool.ru</li>
+              <li>+7 (495) 123-45-67</li>
+              <li>Telegram: @travelproschool</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-700">Документы</h4>
+            <ul class="mt-3 space-y-2 text-sm text-slate-500">
+              <li><a class="transition hover:text-primary" href="#">Политика конфиденциальности</a></li>
+              <li><a class="transition hover:text-primary" href="#">Пользовательское соглашение</a></li>
+              <li><a class="transition hover:text-primary" href="#">Публичная оферта</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </div>
+
+  <script>
+    const mobileToggle = document.getElementById('mobile-toggle');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (mobileToggle && mobileMenu) {
+      mobileToggle.addEventListener('click', () => {
+        mobileMenu.classList.toggle('hidden');
+      });
+      mobileMenu.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => mobileMenu.classList.add('hidden'));
+      });
+    }
+
+    document.querySelectorAll('.faq-item').forEach((item) => {
+      const button = item.querySelector('button');
+      const icon = button.querySelector('svg');
+      button.addEventListener('click', () => {
+        const isOpen = item.classList.toggle('open');
+        icon.style.transform = isOpen ? 'rotate(45deg)' : 'rotate(0deg)';
+        document.querySelectorAll('.faq-item').forEach((other) => {
+          if (other !== item) {
+            other.classList.remove('open');
+            const otherIcon = other.querySelector('svg');
+            if (otherIcon) otherIcon.style.transform = 'rotate(0deg)';
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/new-design/lib/utils.ts
+++ b/new-design/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/new-design/next-env.d.ts
+++ b/new-design/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/new-design/next.config.mjs
+++ b/new-design/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/new-design/package.json
+++ b/new-design/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "travelproschool-new-design",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-hover-card": "^1.0.7",
+    "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.0.4",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.363.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/new-design/postcss.config.mjs
+++ b/new-design/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/new-design/tailwind.config.ts
+++ b/new-design/tailwind.config.ts
@@ -1,0 +1,64 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "1.5rem",
+      screens: {
+        "2xl": "1280px"
+      }
+    },
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "#2D5A87",
+          foreground: "#F8F9FA"
+        },
+        secondary: {
+          DEFAULT: "#F4A261",
+          foreground: "#1F2933"
+        },
+        accent: {
+          DEFAULT: "#E76F51",
+          foreground: "#FDFCFB"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))"
+      },
+      backgroundImage: {
+        "hero-pattern": "linear-gradient(135deg, rgba(45,90,135,0.88) 0%, rgba(38,70,83,0.92) 50%, rgba(231,111,81,0.8) 100%)"
+      },
+      keyframes: {
+        "fade-up": {
+          "0%": { opacity: "0", transform: "translateY(16px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" }
+        }
+      },
+      animation: {
+        "fade-up": "fade-up 0.6s ease-out forwards"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/new-design/tsconfig.json
+++ b/new-design/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a statically rendered new-design/index.html that mirrors the refreshed TravelProSchool experience
- bring over contemporary shadcn-inspired styling, hero, program highlights, mentors, pricing, and FAQ sections
- wire up lightweight interactivity for the mobile menu and accordion FAQ so navigation works without a Next.js server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc3cdac108832cad0c9211eda18ec6